### PR TITLE
Fix build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Prepare release directory
         run: |
           PACKAGE_NAME="cybersec_ai"
-          WHEEL_FILE=$(find . -name '${PACKAGE_NAME}-*-py3-none-any.whl')
-          PACKAGE_VERSION=$(echo "$WHEEL_FILE" | sed -n 's/.*${PACKAGE_NAME}-\(.*\)-py3-none-any\.whl/\1/p')
-          mv $WHEEL_FILE "release/${WHEEL_FILE}"
+          WHEEL_FILE=$(find . -name "${PACKAGE_NAME}-*-py3-none-any.whl")
+          PACKAGE_VERSION=$(echo "$WHEEL_FILE" | sed -n "s/.*${PACKAGE_NAME}-\(.*\)-py3-none-any\.whl/\1/p")
+          mv "$WHEEL_FILE" "release/$(basename "$WHEEL_FILE")"
           chmod +x release/install_cybersec_ai.sh
 
           cp config.json release/
@@ -63,6 +63,9 @@ jobs:
           tree ${PACKAGE_NAME}_${PACKAGE_VERSION} --dirsfirst -F
       - name: Create release tarball
         run: |
+          PACKAGE_NAME="cybersec_ai"
+          WHEEL_FILE=$(find . -name "${PACKAGE_NAME}-*-py3-none-any.whl")
+          PACKAGE_VERSION=$(echo "$WHEEL_FILE" | sed -n "s/.*${PACKAGE_NAME}-\(.*\)-py3-none-any\.whl/\1/p")
           tar -czf ${PACKAGE_NAME}_${PACKAGE_VERSION}.tar.gz ${PACKAGE_NAME}_${PACKAGE_VERSION}
       - name: Upload release tarball
         uses: actions/upload-artifact@v4
@@ -93,6 +96,7 @@ jobs:
           tar -xzf $TAR_FILE
       - name: Run installer script
         run: |
+          TAR_FILE=$(find . -name 'cybersec_ai_*.tar.gz')
           DIR_NAME=$(basename "$TAR_FILE" .tar.gz)
           cd "$DIR_NAME"
           ./install_cybersec_ai.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,22 +52,23 @@ jobs:
       - name: Prepare release directory
         run: |
           PACKAGE_NAME="cybersec_ai"
-          WHEEL_FILE=$(find . -name 'cybersec_ai-*-py3-none-any.whl')
+          WHEEL_FILE=$(find . -name '${PACKAGE_NAME}-*-py3-none-any.whl')
+          PACKAGE_VERSION=$(echo "$WHEEL_FILE" | sed -n 's/.*${PACKAGE_NAME}-\(.*\)-py3-none-any\.whl/\1/p')
           mv $WHEEL_FILE "release/${WHEEL_FILE}"
           chmod +x release/install_cybersec_ai.sh
 
           cp config.json release/
-          mv release ${PACKAGE_NAME}
+          mv release ${PACKAGE_NAME}_${PACKAGE_VERSION}
 
-          tree ${PACKAGE_NAME} --dirsfirst -F
+          tree ${PACKAGE_NAME}_${PACKAGE_VERSION} --dirsfirst -F
       - name: Create release tarball
         run: |
-          tar -czf cybersec_ai.tar.gz cybersec_ai
+          tar -czf ${PACKAGE_NAME}_${PACKAGE_VERSION}.tar.gz ${PACKAGE_NAME}_${PACKAGE_VERSION}
       - name: Upload release tarball
         uses: actions/upload-artifact@v4
         with:
           name: cybersec_ai_release
-          path: cybersec_ai.tar.gz
+          path: ${PACKAGE_NAME}_${PACKAGE_VERSION}.tar.gz
   check_installer:
     runs-on: ubuntu-latest
     needs: create_installer
@@ -88,13 +89,15 @@ jobs:
           name: cybersec_ai_release
       - name: Extract release tarball
         run: |
-          tar -xzf cybersec_ai.tar.gz
+          TAR_FILE=$(find . -name 'cybersec_ai_*.tar.gz')
+          tar -xzf $TAR_FILE
       - name: Run installer script
         run: |
-          cd cybersec_ai
+          DIR_NAME=$(basename "$TAR_FILE" .tar.gz)
+          cd "$DIR_NAME"
           ./install_cybersec_ai.sh
 
-          echo "cybersec_ai/"
+          echo "$DIR_NAME/"
           tree --dirsfirst -F
 
           if [ -f "install_cybersec_ai.sh" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cybersec_ai_release
-          path: ${PACKAGE_NAME}_${PACKAGE_VERSION}.tar.gz
+          path: cybersec_ai_*.tar.gz
   check_installer:
     runs-on: ubuntu-latest
     needs: create_installer


### PR DESCRIPTION
This pull request updates the `.github/workflows/build.yml` file to improve the handling of versioned package artifacts in the CI/CD pipeline. The changes ensure that the package version is dynamically extracted and incorporated into directory and file names, improving traceability and consistency.

### Improvements to artifact versioning and naming:

* Updated the `Prepare release directory` step to dynamically extract the package version from the wheel file name and include it in the release directory name. (`[.github/workflows/build.ymlL55-R74](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L55-R74)`)
* Modified the `Create release tarball` step to include the package version in the tarball name, ensuring version-specific artifacts. (`[.github/workflows/build.ymlL55-R74](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L55-R74)`)

### Adjustments to artifact extraction and usage:

* Enhanced the `Extract release tarball` step to locate and extract versioned tarball files dynamically. (`[.github/workflows/build.ymlL91-R104](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L91-R104)`)
* Updated the `Run installer script` step to navigate into the dynamically named release directory based on the tarball name. (`[.github/workflows/build.ymlL91-R104](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L91-R104)`)